### PR TITLE
feat: all events page and single events page

### DIFF
--- a/src/components/events/index.tsx
+++ b/src/components/events/index.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Calendar, Clock } from "lucide-react";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+
+// Mock data for testing
+// will be replaced with actual data from the db
+export const mockEvents = [
+  {
+    id: "1",
+    title: "AI Workshop: Introduction to Machine Learning",
+    description: "Join us for an introductory workshop on machine learning fundamentals. Perfect for beginners!",
+    date: "2025-05-15",
+    time: "14:00 - 16:00",
+    location: "KTH Campus, Room 123",
+    capacity: 30,
+    image: "/images/events/ml-workshop.jpg",
+    collaborators: [
+      { name: "KTH AI", logo: "/images/collaborators/kth-ai.png" }
+    ]
+  },
+  {
+    id: "2",
+    title: "Tech Talk: The Future of AI",
+    description: "An exciting discussion about the latest trends and future developments in artificial intelligence.",
+    date: "2024-03-20",
+    time: "16:00 - 18:00",
+    location: "KTH Library, Conference Room",
+    capacity: 50,
+    image: "/images/events/ai-talk.jpg",
+    collaborators: [
+      { name: "KTH Innovation", logo: "/images/collaborators/kth-innovation.png" }
+    ]
+  },
+  {
+    id: "3",
+    title: "Hackathon: AI Solutions for Sustainability",
+    description: "A 24-hour hackathon focused on using AI to solve sustainability challenges.",
+    date: "2024-04-01",
+    time: "10:00 - 10:00",
+    location: "KTH Innovation Hub",
+    capacity: 100,
+    image: "/images/events/hackathon.jpg",
+    collaborators: [
+      { name: "Ericsson", logo: "/images/collaborators/ericsson.png" }
+    ]
+  },
+  {
+    id: "4",
+    title: "Networking Event: AI Industry Meetup",
+    description: "Connect with industry professionals and fellow AI enthusiasts.",
+    date: "2024-04-10",
+    time: "17:00 - 19:00",
+    location: "KTH Main Building",
+    capacity: 75,
+    image: "/images/events/networking.jpg",
+    collaborators: [
+      { name: "KTH Career", logo: "/images/collaborators/kth-career.png" }
+    ]
+  },
+  {
+    id: "5",
+    title: "Workshop: Deep Learning with PyTorch",
+    description: "Hands-on workshop covering deep learning concepts using PyTorch.",
+    date: "2024-04-15",
+    time: "13:00 - 17:00",
+    location: "KTH Computer Lab 2",
+    capacity: 25,
+    image: "/images/events/pytorch.jpg",
+    collaborators: [
+      { name: "KTH Computer Science", logo: "/images/collaborators/kth-cs.png" }
+    ]
+  }
+];
+
+// Format date consistently
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+}
+
+function getEventStatus(date: string, time: string): { status: "upcoming" | "past"; label: string } {
+  const eventDateTime = new Date(`${date}T${time.split(" - ")[0]}`);
+  const now = new Date();
+  
+  if (eventDateTime < now) {
+    return { status: "past", label: "Past Event" };
+  }
+  return { status: "upcoming", label: "Upcoming" };
+}
+
+export function EventsView() {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Simulate loading state - remove this in production
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Scroll to the latest event (leftmost) when component mounts
+  useEffect(() => {
+    if (scrollContainerRef.current && !isLoading) {
+      scrollContainerRef.current.scrollLeft = 0;
+    }
+  }, [isLoading]);
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-6 py-12 flex flex-col items-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-6 py-12">
+      <h1 className="text-3xl font-bold mb-12">Upcoming Events</h1>
+      
+      {/* Horizontal Scroll Container */}
+      <div 
+        ref={scrollContainerRef}
+        className="relative w-full overflow-x-auto pb-6 pt-2 -mt-2 scrollbar-none scroll-smooth snap-x snap-mandatory"
+      >
+        <div className="flex gap-6 min-w-min px-1">
+          {[...mockEvents]
+            .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+            .map((event) => {
+              if (!event?.date || !event?.time) return null;
+              const { status, label } = getEventStatus(event.date, event.time);
+              
+              return (
+                <Link 
+                  href={`/events/${event.id}`} 
+                  key={event.id}
+                  className="block w-[350px] flex-shrink-0 snap-start transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
+                >
+                  <Card className="h-full flex flex-col">
+                    {/* Event Image with Status Badge */}
+                    <div className="relative w-full h-48">
+                      <Image
+                        src={event.image}
+                        alt={event.title}
+                        fill
+                        className="object-cover rounded-t-xl"
+                      />
+                      <div className="absolute top-2 right-2">
+                        <Badge 
+                          variant={status === "upcoming" ? "default" : "secondary"}
+                          className="flex items-center gap-1"
+                        >
+                          {status === "upcoming" ? (
+                            <Clock className="h-3 w-3" />
+                          ) : (
+                            <Calendar className="h-3 w-3" />
+                          )}
+                          {label}
+                        </Badge>
+                      </div>
+                    </div>
+
+                    <CardHeader className="flex-none">
+                      <CardTitle className="text-xl line-clamp-2">{event.title}</CardTitle>
+                      <div className="text-sm text-muted-foreground flex items-center gap-2">
+                        <Calendar className="h-4 w-4 flex-shrink-0" />
+                        {formatDate(event.date)}
+                      </div>
+                    </CardHeader>
+
+                    <CardContent className="flex-grow flex flex-col">
+                      <p className="text-sm text-muted-foreground mb-4 line-clamp-3">
+                        {event.description}
+                      </p>
+                      
+                      <div className="flex flex-col gap-2 mb-4 mt-auto">
+                        <div className="text-sm">
+                          <span className="font-medium">Location:</span>{" "}
+                          <span className="line-clamp-1">{event.location}</span>
+                        </div>
+                        <div className="text-sm flex items-center gap-2">
+                          <Clock className="h-4 w-4 flex-shrink-0" />
+                          <span className="font-medium">Time:</span> {event.time}
+                        </div>
+                        {event.capacity && (
+                          <div className="text-sm">
+                            <span className="font-medium">Capacity:</span> {event.capacity}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Collaborators */}
+                      <div className="mt-4 pt-4 border-t">
+                        <div className="text-sm font-medium mb-2">Collaborators</div>
+                        <div className="flex flex-wrap gap-2">
+                          {event.collaborators.map((collaborator) => (
+                            <div 
+                              key={collaborator.name}
+                              className="flex items-center gap-2 bg-muted/50 px-2 py-1 rounded-md"
+                            >
+                              <div className="relative w-4 h-4 flex-shrink-0">
+                                <Image
+                                  src={collaborator.logo}
+                                  alt={collaborator.name}
+                                  fill
+                                  className="object-contain"
+                                />
+                              </div>
+                              <span className="text-xs line-clamp-1">{collaborator.name}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              );
+            })}
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/src/components/events/single-event.tsx
+++ b/src/components/events/single-event.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Calendar, Clock, MapPin, Users, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { formatDate } from "./utils";
+
+// Temporary test event
+const testEvent = {
+  id: "1",
+  title: "AI Workshop: Introduction to Machine Learning",
+  description: "Join us for an introductory workshop on machine learning fundamentals. Perfect for beginners! This workshop will cover the basics of machine learning, including supervised and unsupervised learning, neural networks, and practical applications. No prior experience required.",
+  date: "2025-05-15",
+  time: "14:00 - 16:00",
+  location: "KTH Campus, Room 123",
+  capacity: 30,
+  image: "/images/brand_assets/ais-logo-main-long-white-1.jpg",
+  collaborators: [
+    { name: "KTH Computer Science", logo: "/images/collaborators/kth-cs.png" }
+  ]
+};
+
+interface Collaborator {
+  name: string;
+  logo: string;
+}
+
+interface Event {
+  id: string;
+  title: string;
+  description: string;
+  date: string;
+  time: string;
+  location: string;
+  capacity: number;
+  image: string;
+  collaborators: Collaborator[];
+}
+
+interface SingleEventProps {
+  event?: Event;
+}
+
+export function SingleEvent({ event = testEvent }: SingleEventProps) {
+  if (!event) {
+    return (
+      <div className="container mx-auto px-6 py-12">
+        <h1 className="text-3xl font-bold mb-4">Event Not Found</h1>
+        <p className="text-muted-foreground mb-8">
+          The event you're looking for doesn't exist or has been removed.
+        </p>
+        <Link 
+          href="/events"
+          className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Events
+        </Link>
+      </div>
+    );
+  }
+
+  const { status, label } = getEventStatus(event.date, event.time);
+
+  return (
+    <div className="container mx-auto px-6 py-12">
+      {/* Back button */}
+      <Link 
+        href="/events"
+        className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-8 transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to Events
+      </Link>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Main content */}
+        <div className="lg:col-span-2 space-y-8">
+          {/* Event Image */}
+          <div className="relative w-full h-[400px] rounded-xl overflow-hidden">
+            <Image
+              src={event.image}
+              alt={event.title}
+              fill
+              className="object-cover"
+              priority
+            />
+            <div className="absolute top-4 right-4">
+              <Badge 
+                variant={status === "upcoming" ? "default" : "secondary"}
+                className="flex items-center gap-1 text-base px-4 py-1"
+              >
+                {status === "upcoming" ? (
+                  <Clock className="h-4 w-4" />
+                ) : (
+                  <Calendar className="h-4 w-4" />
+                )}
+                {label}
+              </Badge>
+            </div>
+          </div>
+
+          {/* Event Details */}
+          <div className="space-y-6">
+            <div>
+              <h1 className="text-3xl font-bold mb-4">{event.title}</h1>
+              <p className="text-muted-foreground text-lg leading-relaxed">
+                {event.description}
+              </p>
+            </div>
+
+            {/* Event Info Grid */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="flex items-start gap-3">
+                <Calendar className="h-5 w-5 text-muted-foreground mt-0.5" />
+                <div>
+                  <h3 className="font-medium mb-1">Date</h3>
+                  <p className="text-muted-foreground">{formatDate(event.date)}</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <Clock className="h-5 w-5 text-muted-foreground mt-0.5" />
+                <div>
+                  <h3 className="font-medium mb-1">Time</h3>
+                  <p className="text-muted-foreground">{event.time}</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <MapPin className="h-5 w-5 text-muted-foreground mt-0.5" />
+                <div>
+                  <h3 className="font-medium mb-1">Location</h3>
+                  <p className="text-muted-foreground">{event.location}</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <Users className="h-5 w-5 text-muted-foreground mt-0.5" />
+                <div>
+                  <h3 className="font-medium mb-1">Capacity</h3>
+                  <p className="text-muted-foreground">{event.capacity} participants</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Collaborators */}
+            <div>
+              <h2 className="text-xl font-semibold mb-4">Collaborators</h2>
+              <div className="flex flex-wrap gap-4">
+                {event.collaborators.map((collaborator) => (
+                  <div 
+                    key={collaborator.name}
+                    className="flex items-center gap-3 bg-muted/50 px-4 py-2 rounded-lg"
+                  >
+                    <div className="relative w-8 h-8">
+                      <Image
+                        src={collaborator.logo}
+                        alt={collaborator.name}
+                        fill
+                        className="object-contain"
+                      />
+                    </div>
+                    <span className="font-medium">{collaborator.name}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Registration Sidebar */}
+        <div className="lg:col-span-1">
+          <Card className="sticky top-8">
+            <CardHeader>
+              <CardTitle>Register for this Event</CardTitle>
+              <CardDescription>
+                {status === "upcoming" 
+                  ? "Secure your spot at this upcoming event"
+                  : "This event has already taken place"}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {status === "upcoming" ? (
+                <Button 
+                  size="lg" 
+                  className="w-full"
+                  onClick={() => {
+                    // TODO: Implement registration logic 
+                    // right now the button has no functionality
+                    console.log("Register for event:", event.id);
+                  }}
+                >
+                  Register Now
+                </Button>
+              ) : (
+                <Button 
+                  size="lg" 
+                  variant="secondary" 
+                  className="w-full"
+                  disabled
+                >
+                  Event Ended
+                </Button>
+              )}
+
+              <div className="pt-6 border-t">
+                <h3 className="font-medium mb-2">Event Details</h3>
+                <ul className="space-y-2 text-sm text-muted-foreground">
+                  <li>• Free admission</li>
+                  <li>• Open to all KTH students</li>
+                  <li>• Registration required</li>
+                </ul>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getEventStatus(date: string, time: string): { status: "upcoming" | "past"; label: string } {
+  const eventDateTime = new Date(`${date}T${time.split(" - ")[0]}`);
+  const now = new Date();
+  
+  if (eventDateTime < now) {
+    return { status: "past", label: "Past Event" };
+  }
+  return { status: "upcoming", label: "Upcoming" };
+}

--- a/src/components/events/utils.ts
+++ b/src/components/events/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Formats a date string into a human-readable format
+ * @param dateString - The date string to format (e.g. "2024-03-15")
+ * @returns A formatted date string (e.g. "March 15, 2024")
+ */
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+} 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-[#1751A6] text-white hover:bg-[#1751A6]/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(badgeVariants({ variant }), className)}
+        {...props}
+      />
+    );
+  }
+);
+Badge.displayName = "Badge";
+
+export { Badge, badgeVariants }; 

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -2,8 +2,8 @@ import { twJoin } from "tailwind-merge";
 
 export function LoadingSpinner({
   label,
-  color = "text-white",
-  size = "5",
+  color = "text-black",
+  size = "10",
 }: {
   label?: string;
   color?: string;

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+
+export interface Collaborator {
+  name: string;
+  logo: string;
+}
+
+export interface Event {
+  id: string;
+  title: string;
+  description: string;
+  date: string;
+  time: string;
+  location: string;
+  capacity?: number;
+  image: string;
+  collaborators?: Collaborator[];
+}
+
+// not sure how to call the db to get event info right now so this is just mock data
+// not even in use at the moment 
+
+async function fetchEvents(): Promise<Event[]> {
+  const API_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080") + "/api/v1";
+  const response = await fetch(`${API_URL}/events`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch events");
+  }
+
+  return response.json();
+}
+
+export function useEvents() {
+  return useQuery({
+    queryKey: ["events"],
+    queryFn: fetchEvents,
+    select: (data) => {
+      // Sort events by date (newest first) and take the latest 10
+      return data
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+        .slice(0, 10);
+    },
+  });
+} 


### PR DESCRIPTION
Page for events implemented, scroll from the newest to the oldest (among latest 10 events)

Not getting events from database now, mock events used for testing 

Single event page: does not show map (like the old website). 

Single event page: registration card does not have functionality for registration right now, since I am unsure how we will handle the registration here.

Note: Color scheme is a bit off (besides the UI components) since I expect we will make global changes to colors?
