### PR TITLE
Expand newsletter signup to full applicant fields, add application op…

### DIFF
--- a/src/app/newsletter/newsletter-form.tsx
+++ b/src/app/newsletter/newsletter-form.tsx
@@ -159,7 +159,7 @@ const defaultNewsletterValues: NewsletterFormValues = {
   lastName: "",
   email: "",
   gender: "",
-  university: UNIVERSITIES[0],
+  university: "",
   universityOther: "",
   programme: "",
   programmeOther: "",
@@ -380,6 +380,9 @@ function NewsletterFormFields({
                     }}
                     aria-invalid={isInvalid}
                   >
+                    <NativeSelectOption value="">
+                      Select your university
+                    </NativeSelectOption>
                     {UNIVERSITIES.map((university) => (
                       <NativeSelectOption key={university} value={university}>
                         {university}
@@ -472,7 +475,7 @@ function NewsletterFormFields({
                             setSubmitState(null)
                             field.handleChange(event.target.value)
                           }}
-                          placeholder="Your university and degree"
+                          placeholder="Enter your programme or degree"
                           aria-invalid={isInvalid}
                         />
                         {isInvalid ? (

--- a/src/app/newsletter/newsletter-form.tsx
+++ b/src/app/newsletter/newsletter-form.tsx
@@ -34,8 +34,14 @@ import {
   OTHER_UNIVERSITY_VALUE,
   UNIVERSITIES,
   getGraduationYearOptions,
+  resolveUniversity,
+  resolveProgramme,
   type ApplicationGender,
 } from "@/types/applications"
+import {
+  fieldIsInvalid,
+  selectableOptionBoxClassName,
+} from "@/lib/form-field-utils"
 import { useSubmitNewsletterSubscription } from "@/hooks/newsletter"
 
 const GRADUATION_YEAR_OPTIONS = getGraduationYearOptions()
@@ -129,30 +135,6 @@ const newsletterSchema = z
       })
     }
   })
-
-function resolveUniversity(values: Pick<NewsletterFormValues, "university" | "universityOther">) {
-  return values.university === OTHER_UNIVERSITY_VALUE
-    ? values.universityOther.trim()
-    : values.university.trim()
-}
-
-function resolveProgramme(values: Pick<NewsletterFormValues, "programme" | "programmeOther">) {
-  return values.programme === OTHER_PROGRAMME_VALUE
-    ? values.programmeOther.trim()
-    : values.programme.trim()
-}
-
-function fieldIsInvalid(meta: { isTouched: boolean; isValid: boolean }) {
-  return meta.isTouched && !meta.isValid
-}
-
-function selectableOptionBoxClassName(isSelected: boolean, isInvalid = false) {
-  return cn(
-    "flex items-center gap-3 rounded-lg border p-3 text-sm transition-colors hover:bg-secondary/20",
-    isSelected && "border-primary/40 bg-primary/5",
-    isInvalid && !isSelected && "border-destructive/50",
-  )
-}
 
 const defaultNewsletterValues: NewsletterFormValues = {
   firstName: "",

--- a/src/app/newsletter/newsletter-form.tsx
+++ b/src/app/newsletter/newsletter-form.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils"
 import { AsciiGrid } from "@/components/ui/ascii-grid"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
@@ -17,30 +18,155 @@ import {
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
   InputGroupText,
 } from "@/components/ui/input-group"
-import { API_URL } from "@/config"
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select"
+import { ProgrammeSelect } from "@/components/member/programme-select"
+import {
+  APPLICATION_GENDERS,
+  APPLICATION_INTERESTS,
+  OTHER_PROGRAMME_VALUE,
+  OTHER_UNIVERSITY_VALUE,
+  UNIVERSITIES,
+  getGraduationYearOptions,
+  type ApplicationGender,
+} from "@/types/applications"
+import { useSubmitNewsletterSubscription } from "@/hooks/newsletter"
 
-const newsletterSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, "Please enter your name.")
-    .max(80, "Please keep your name under 80 characters."),
-  email: z
-    .string()
-    .trim()
-    .min(1, "Please enter your email address.")
-    .refine(
-      (value) =>
-        value.length === 0 || z.string().email().safeParse(value).success,
-      "Please enter a valid email address."
-    ),
-})
+const GRADUATION_YEAR_OPTIONS = getGraduationYearOptions()
+
+type NewsletterFormValues = {
+  firstName: string
+  lastName: string
+  email: string
+  gender: ApplicationGender | ""
+  university: string
+  universityOther: string
+  programme: string
+  programmeOther: string
+  graduationYear: string
+  interests: (typeof APPLICATION_INTERESTS)[number][]
+  dataRetentionConsent: boolean
+}
+
+const newsletterSchema = z
+  .object({
+    firstName: z
+      .string()
+      .trim()
+      .min(1, "Please enter your first name.")
+      .max(80, "Please keep your first name under 80 characters."),
+    lastName: z
+      .string()
+      .trim()
+      .min(1, "Please enter your last name.")
+      .max(80, "Please keep your last name under 80 characters."),
+    email: z
+      .string()
+      .trim()
+      .min(1, "Please enter your email address.")
+      .email("Please enter a valid email address."),
+    gender: z
+      .union([z.enum(APPLICATION_GENDERS), z.literal("")])
+      .refine((value) => value !== "", "Please select your gender."),
+    university: z.string().trim().min(1, "Please select your university."),
+    universityOther: z
+      .string()
+      .trim()
+      .max(120, "Please keep your university under 120 characters."),
+    programme: z.string().trim().min(1, "Please select your programme."),
+    programmeOther: z
+      .string()
+      .trim()
+      .max(120, "Please keep your programme under 120 characters."),
+    graduationYear: z
+      .string()
+      .trim()
+      .refine(
+        (value) => GRADUATION_YEAR_OPTIONS.includes(value),
+        "Please select your expected graduation year.",
+      ),
+    interests: z
+      .array(z.enum(APPLICATION_INTERESTS))
+      .min(1, "Choose at least one area of interest.")
+      .refine(
+        (interests) => new Set(interests).size === interests.length,
+        "Each interest can appear only once.",
+      ),
+    dataRetentionConsent: z
+      .boolean()
+      .refine(
+        (value) => value,
+        "You need to consent to data collection and storage before subscribing.",
+      ),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.university === OTHER_UNIVERSITY_VALUE &&
+      value.universityOther.trim().length === 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["universityOther"],
+        message: "Please enter your university.",
+      })
+    }
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.programme === OTHER_PROGRAMME_VALUE &&
+      value.programmeOther.trim().length === 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["programmeOther"],
+        message: "Please enter your programme or degree.",
+      })
+    }
+  })
+
+function resolveUniversity(values: Pick<NewsletterFormValues, "university" | "universityOther">) {
+  return values.university === OTHER_UNIVERSITY_VALUE
+    ? values.universityOther.trim()
+    : values.university.trim()
+}
+
+function resolveProgramme(values: Pick<NewsletterFormValues, "programme" | "programmeOther">) {
+  return values.programme === OTHER_PROGRAMME_VALUE
+    ? values.programmeOther.trim()
+    : values.programme.trim()
+}
+
+function fieldIsInvalid(meta: { isTouched: boolean; isValid: boolean }) {
+  return meta.isTouched && !meta.isValid
+}
+
+function selectableOptionBoxClassName(isSelected: boolean, isInvalid = false) {
+  return cn(
+    "flex items-center gap-3 rounded-lg border p-3 text-sm transition-colors hover:bg-secondary/20",
+    isSelected && "border-primary/40 bg-primary/5",
+    isInvalid && !isSelected && "border-destructive/50",
+  )
+}
+
+const defaultNewsletterValues: NewsletterFormValues = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  gender: "",
+  university: UNIVERSITIES[0],
+  universityOther: "",
+  programme: "",
+  programmeOther: "",
+  graduationYear: "",
+  interests: [],
+  dataRetentionConsent: false,
+}
 
 type SubmitState =
   | {
@@ -58,12 +184,10 @@ function NewsletterFormFields({
   className,
 }: Omit<NewsletterFormProps, "variant">) {
   const [submitState, setSubmitState] = useState<SubmitState>(null)
+  const submitNewsletterSubscription = useSubmitNewsletterSubscription()
 
   const form = useForm({
-    defaultValues: {
-      name: "",
-      email: "",
-    },
+    defaultValues: defaultNewsletterValues,
     validators: {
       onBlur: newsletterSchema,
       onSubmit: newsletterSchema,
@@ -71,26 +195,23 @@ function NewsletterFormFields({
     onSubmit: async ({ value }) => {
       setSubmitState(null)
 
-      const response = await fetch(`${API_URL}/newsletter/subscribe`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: value.name.trim(),
-          email: value.email.trim(),
-        }),
-      })
-
-      const data = (await response.json().catch(() => null)) as
-        | { error?: string }
-        | null
-
-      if (!response.ok) {
+      try {
+        await submitNewsletterSubscription.mutateAsync({
+          firstName: value.firstName,
+          lastName: value.lastName,
+          email: value.email,
+          gender: value.gender as ApplicationGender,
+          university: resolveUniversity(value),
+          programme: resolveProgramme(value),
+          graduationYear: Number(value.graduationYear),
+          interests: value.interests,
+          dataRetentionConsent: value.dataRetentionConsent,
+        })
+      } catch (error) {
         setSubmitState({
           type: "error",
-          message: data?.error ?? "Failed to subscribe.",
+          message:
+            error instanceof Error ? error.message : "Failed to subscribe.",
         })
         return
       }
@@ -107,52 +228,72 @@ function NewsletterFormFields({
     <form
       id="newsletter-form"
       noValidate
-      className={cn("w-full sm:max-w-md", className)}
+      className={cn("w-full", className)}
       onSubmit={(event) => {
         event.preventDefault()
         void form.handleSubmit()
       }}
     >
       <FieldGroup>
-        <form.Field name="name">
-          {(field) => {
-            const isInvalid =
-              field.state.meta.isTouched && !field.state.meta.isValid
-
-            return (
-              <Field data-invalid={isInvalid}>
-                <FieldLabel htmlFor={field.name}>Name</FieldLabel>
-                <InputGroup>
-                  <InputGroupInput
+        <div className="grid gap-5 sm:grid-cols-2">
+          <form.Field name="firstName">
+            {(field) => {
+              const isInvalid = fieldIsInvalid(field.state.meta)
+              return (
+                <Field data-invalid={isInvalid}>
+                  <FieldLabel htmlFor={field.name}>First name</FieldLabel>
+                  <Input
                     id={field.name}
                     name={field.name}
-                    type="text"
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={(event) => {
                       setSubmitState(null)
                       field.handleChange(event.target.value)
                     }}
-                    placeholder="Alan Turing"
-                    autoComplete="name"
+                    placeholder="Alan"
+                    autoComplete="given-name"
                     aria-invalid={isInvalid}
                   />
-                </InputGroup>
-                <FieldDescription>
-                  We&apos;ll use your name in newsletter emails.
-                </FieldDescription>
-                {isInvalid ? (
-                  <FieldError errors={field.state.meta.errors} />
-                ) : null}
-              </Field>
-            )
-          }}
-        </form.Field>
+                  {isInvalid ? (
+                    <FieldError errors={field.state.meta.errors} />
+                  ) : null}
+                </Field>
+              )
+            }}
+          </form.Field>
+
+          <form.Field name="lastName">
+            {(field) => {
+              const isInvalid = fieldIsInvalid(field.state.meta)
+              return (
+                <Field data-invalid={isInvalid}>
+                  <FieldLabel htmlFor={field.name}>Last name</FieldLabel>
+                  <Input
+                    id={field.name}
+                    name={field.name}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      setSubmitState(null)
+                      field.handleChange(event.target.value)
+                    }}
+                    placeholder="Turing"
+                    autoComplete="family-name"
+                    aria-invalid={isInvalid}
+                  />
+                  {isInvalid ? (
+                    <FieldError errors={field.state.meta.errors} />
+                  ) : null}
+                </Field>
+              )
+            }}
+          </form.Field>
+        </div>
 
         <form.Field name="email">
           {(field) => {
-            const isInvalid =
-              field.state.meta.isTouched && !field.state.meta.isValid
+            const isInvalid = fieldIsInvalid(field.state.meta)
 
             return (
               <Field data-invalid={isInvalid}>
@@ -179,6 +320,281 @@ function NewsletterFormFields({
                 <FieldDescription>
                   We&apos;ll only send updates related to the KTH AI community.
                 </FieldDescription>
+                {isInvalid ? (
+                  <FieldError errors={field.state.meta.errors} />
+                ) : null}
+              </Field>
+            )
+          }}
+        </form.Field>
+
+        <form.Field name="gender">
+          {(field) => {
+            const isInvalid = fieldIsInvalid(field.state.meta)
+            return (
+              <Field data-invalid={isInvalid}>
+                <FieldLabel htmlFor={field.name}>Gender</FieldLabel>
+                <NativeSelect
+                  id={field.name}
+                  name={field.name}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => {
+                    setSubmitState(null)
+                    field.handleChange(event.target.value as ApplicationGender | "")
+                  }}
+                  aria-invalid={isInvalid}
+                >
+                  <NativeSelectOption value="">
+                    Select your gender
+                  </NativeSelectOption>
+                  {APPLICATION_GENDERS.map((gender) => (
+                    <NativeSelectOption key={gender} value={gender}>
+                      {gender}
+                    </NativeSelectOption>
+                  ))}
+                </NativeSelect>
+                {isInvalid ? (
+                  <FieldError errors={field.state.meta.errors} />
+                ) : null}
+              </Field>
+            )
+          }}
+        </form.Field>
+
+        <div className="grid gap-5 sm:grid-cols-2">
+          <form.Field name="university">
+            {(field) => {
+              const isInvalid = fieldIsInvalid(field.state.meta)
+              return (
+                <Field data-invalid={isInvalid}>
+                  <FieldLabel htmlFor={field.name}>University</FieldLabel>
+                  <NativeSelect
+                    id={field.name}
+                    name={field.name}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      setSubmitState(null)
+                      field.handleChange(event.target.value)
+                    }}
+                    aria-invalid={isInvalid}
+                  >
+                    {UNIVERSITIES.map((university) => (
+                      <NativeSelectOption key={university} value={university}>
+                        {university}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                  {isInvalid ? (
+                    <FieldError errors={field.state.meta.errors} />
+                  ) : null}
+                </Field>
+              )
+            }}
+          </form.Field>
+
+          <form.Subscribe selector={(state) => state.values.university}>
+            {(university) =>
+              university === OTHER_UNIVERSITY_VALUE ? (
+                <form.Field name="universityOther">
+                  {(field) => {
+                    const isInvalid = fieldIsInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>
+                          Other university
+                        </FieldLabel>
+                        <Input
+                          id={field.name}
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) => {
+                            setSubmitState(null)
+                            field.handleChange(event.target.value)
+                          }}
+                          placeholder="Enter your university"
+                          aria-invalid={isInvalid}
+                        />
+                        {isInvalid ? (
+                          <FieldError errors={field.state.meta.errors} />
+                        ) : null}
+                      </Field>
+                    )
+                  }}
+                </form.Field>
+              ) : null
+            }
+          </form.Subscribe>
+
+          <form.Field name="programme">
+            {(field) => {
+              const isInvalid = fieldIsInvalid(field.state.meta)
+              return (
+                <Field data-invalid={isInvalid}>
+                  <ProgrammeSelect
+                    id={field.name}
+                    value={field.state.value}
+                    onValueChange={(programme) => {
+                      setSubmitState(null)
+                      field.handleChange(programme)
+                      field.handleBlur()
+                    }}
+                    placeholder="Engineering Physics"
+                    customOptions={[OTHER_PROGRAMME_VALUE]}
+                  />
+                  {isInvalid ? (
+                    <FieldError errors={field.state.meta.errors} />
+                  ) : null}
+                </Field>
+              )
+            }}
+          </form.Field>
+
+          <form.Subscribe selector={(state) => state.values.programme}>
+            {(programme) =>
+              programme === OTHER_PROGRAMME_VALUE ? (
+                <form.Field name="programmeOther">
+                  {(field) => {
+                    const isInvalid = fieldIsInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>
+                          Programme or degree
+                        </FieldLabel>
+                        <Input
+                          id={field.name}
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) => {
+                            setSubmitState(null)
+                            field.handleChange(event.target.value)
+                          }}
+                          placeholder="Your university and degree"
+                          aria-invalid={isInvalid}
+                        />
+                        {isInvalid ? (
+                          <FieldError errors={field.state.meta.errors} />
+                        ) : null}
+                      </Field>
+                    )
+                  }}
+                </form.Field>
+              ) : null
+            }
+          </form.Subscribe>
+
+          <form.Field name="graduationYear">
+            {(field) => {
+              const isInvalid = fieldIsInvalid(field.state.meta)
+              return (
+                <Field data-invalid={isInvalid}>
+                  <FieldLabel htmlFor={field.name}>
+                    Expected graduation year
+                  </FieldLabel>
+                  <NativeSelect
+                    id={field.name}
+                    name={field.name}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      setSubmitState(null)
+                      field.handleChange(event.target.value)
+                    }}
+                    aria-invalid={isInvalid}
+                  >
+                    <NativeSelectOption value="">
+                      Select graduation year
+                    </NativeSelectOption>
+                    {GRADUATION_YEAR_OPTIONS.map((year) => (
+                      <NativeSelectOption key={year} value={year}>
+                        {year}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                  {isInvalid ? (
+                    <FieldError errors={field.state.meta.errors} />
+                  ) : null}
+                </Field>
+              )
+            }}
+          </form.Field>
+        </div>
+
+        <form.Field name="interests">
+          {(field) => {
+            const isInvalid = fieldIsInvalid(field.state.meta)
+            const toggleInterest = (interest: (typeof APPLICATION_INTERESTS)[number]) => {
+              setSubmitState(null)
+              const isSelected = field.state.value.includes(interest)
+              field.handleChange(
+                isSelected
+                  ? field.state.value.filter((value) => value !== interest)
+                  : [...field.state.value, interest],
+              )
+              field.handleBlur()
+            }
+            return (
+              <Field data-invalid={isInvalid}>
+                <FieldLabel>Areas of interest</FieldLabel>
+                <FieldDescription>
+                  Select at least one industry or area you&apos;d like to hear
+                  about.
+                </FieldDescription>
+                <div className="grid gap-3 sm:grid-cols-2" aria-invalid={isInvalid}>
+                  {APPLICATION_INTERESTS.map((interest) => {
+                    const isSelected = field.state.value.includes(interest)
+                    return (
+                      <label
+                        key={interest}
+                        className={selectableOptionBoxClassName(isSelected, isInvalid)}
+                      >
+                        <Checkbox
+                          checked={isSelected}
+                          onCheckedChange={() => toggleInterest(interest)}
+                          aria-invalid={isInvalid}
+                        />
+                        <span className="font-medium">{interest}</span>
+                      </label>
+                    )
+                  })}
+                </div>
+                {isInvalid ? (
+                  <FieldError errors={field.state.meta.errors} />
+                ) : null}
+              </Field>
+            )
+          }}
+        </form.Field>
+
+        <form.Field name="dataRetentionConsent">
+          {(field) => {
+            const isInvalid = fieldIsInvalid(field.state.meta)
+            return (
+              <Field data-invalid={isInvalid}>
+                <label className="flex items-start gap-3 rounded-lg border p-4 text-sm">
+                  <Checkbox
+                    className="mt-0.5"
+                    checked={field.state.value}
+                    onCheckedChange={(value) => {
+                      setSubmitState(null)
+                      field.handleChange(Boolean(value))
+                      field.handleBlur()
+                    }}
+                    aria-invalid={isInvalid}
+                  />
+                  <span className="space-y-1">
+                    <span className="block font-medium">
+                      I consent to KTH AI Society collecting and storing my
+                      information to send me newsletter updates.
+                    </span>
+                    <span className="block text-muted-foreground">
+                      You can unsubscribe at any time.
+                    </span>
+                  </span>
+                </label>
                 {isInvalid ? (
                   <FieldError errors={field.state.meta.errors} />
                 ) : null}
@@ -292,29 +708,29 @@ export function NewsletterForm({
       </section>
 
       <div className="px-4 sm:px-6 md:px-8 lg:px-8 xl:px-8">
-        <section className="relative z-20 mx-auto -mt-24 mb-24 flex max-w-7xl flex-col gap-8 rounded-3xl border bg-neutral-50 p-4 shadow-lg md:p-8">
-          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div className="flex max-w-3xl flex-col gap-2">
-              <div>
-                <Link
-                  href="/"
-                  className="text-sm font-medium text-secondary-gray transition-colors hover:text-primary"
-                >
-                  Home
-                </Link>
-                <span className="mx-2 text-gray-300">/</span>
-                <span className="text-sm font-medium text-primary">
-                  Newsletter
-                </span>
-              </div>
-              <p className="max-w-2xl text-lg leading-relaxed opacity-95 md:text-xl">
-                Join our mailing list for major society updates, upcoming
-                events, new projects, and curated AI community news.
-              </p>
+        <section className="relative z-20 mx-auto -mt-24 mb-24 flex max-w-7xl flex-col items-center gap-8 rounded-3xl border bg-neutral-50 p-4 text-center shadow-lg md:p-8">
+          <div className="flex w-full max-w-3xl flex-col items-center gap-2">
+            <div>
+              <Link
+                href="/"
+                className="text-sm font-medium text-secondary-gray transition-colors hover:text-primary"
+              >
+                Home
+              </Link>
+              <span className="mx-2 text-gray-300">/</span>
+              <span className="text-sm font-medium text-primary">
+                Newsletter
+              </span>
             </div>
+            <p className="max-w-2xl text-lg leading-relaxed opacity-95 md:text-xl">
+              Join our mailing list for major society updates, upcoming
+              events, new projects, and curated AI community news.
+            </p>
           </div>
 
-          <NewsletterFormFields className={cn("sm:max-w-lg", className)} />
+          <div className="flex w-full justify-center text-left">
+            <NewsletterFormFields className={cn("w-full max-w-4xl", className)} />
+          </div>
         </section>
       </div>
     </div>

--- a/src/components/applications/application-form.tsx
+++ b/src/components/applications/application-form.tsx
@@ -57,9 +57,11 @@ import {
   type ApplicationTeam,
   APPLICATION_INTERESTS,
   type ApplicationInterest,
+  OTHER_UNIVERSITY_VALUE,
+  OTHER_PROGRAMME_VALUE,
+  UNIVERSITIES,
+  getGraduationYearOptions,
 } from "@/types/applications";
-
-const OTHER_PROGRAMME_VALUE = "Other / not listed";
 
 const LINKEDIN_HANDLE_PREFIX = "linkedin.com/in/";
 const LINKEDIN_HANDLE_PATTERN = /^[A-Za-z0-9_-]{3,100}$/;
@@ -79,20 +81,8 @@ function buildLinkedInUrl(handle: string) {
 
 const MAX_RESUME_BYTES = 10 * 1024 * 1024;
 const RESUME_EXTENSIONS = [".pdf", ".doc", ".docx"] as const;
-const OTHER_UNIVERSITY_VALUE = "Other";
-const STOCKHOLM_UNIVERSITIES = [
-  "KTH Royal Institute of Technology",
-  "Stockholm University",
-  "Stockholm School of Economics",
-  "Karolinska Institutet",
-  "Södertörn University",
-  OTHER_UNIVERSITY_VALUE,
-] as const;
-const CURRENT_GRADUATION_YEAR = new Date().getFullYear();
-const GRADUATION_YEAR_OPTIONS = Array.from({ length: 6 }, (_, index) =>
-  // length: 6 is for 6 years from current year - suitable for people who are starting their 5-year studies this year
-  String(CURRENT_GRADUATION_YEAR + index),
-);
+const STOCKHOLM_UNIVERSITIES = UNIVERSITIES;
+const GRADUATION_YEAR_OPTIONS = getGraduationYearOptions();
 const RESUME_MIME_TYPES = [
   "application/pdf",
   "application/msword",
@@ -165,6 +155,7 @@ type ApplicationFormValues = {
   availability: ApplicationAvailability | "";
   contribution: string;
   dataRetentionConsent: boolean;
+  newsletterOptIn: boolean;
 };
 
 function resolveUniversity(values: Pick<ApplicationFormValues, "university" | "universityOther">) {
@@ -310,6 +301,7 @@ const applicationBaseSchema = z.object({
       (value) => value,
       "You need to consent to data collection and storage before submitting.",
     ),
+  newsletterOptIn: z.boolean(),
 });
 
 function validateUniversityOther(
@@ -377,6 +369,7 @@ const stepSchemas = [
   }),
   applicationBaseSchema.pick({
     dataRetentionConsent: true,
+    newsletterOptIn: true,
   }),
 ] as const;
 
@@ -402,6 +395,9 @@ const applicationFieldValidators = {
   contribution: { onBlur: applicationBaseSchema.shape.contribution },
   dataRetentionConsent: {
     onChange: applicationBaseSchema.shape.dataRetentionConsent,
+  },
+  newsletterOptIn: {
+    onChange: applicationBaseSchema.shape.newsletterOptIn,
   },
 };
 
@@ -438,6 +434,7 @@ const defaultApplicationValues: ApplicationFormValues = {
   availability: "",
   contribution: "",
   dataRetentionConsent: false,
+  newsletterOptIn: false,
 };
 
 function ApplicationWizardProgress({
@@ -1026,6 +1023,7 @@ export function ApplicationForm() {
           availability: parsed.data.availability,
           contribution: parsed.data.contribution,
           dataRetentionConsent: parsed.data.dataRetentionConsent,
+          newsletterOptIn: parsed.data.newsletterOptIn,
         });
         setSubmitState({
           type: "success",
@@ -1266,6 +1264,34 @@ export function ApplicationForm() {
                         </Field>
                       );
                     }}
+                  </form.Field>
+
+                  <form.Field name="newsletterOptIn">
+                    {(field) => (
+                      <Field>
+                        <label className="flex items-start gap-3 rounded-lg border p-4 text-sm">
+                          <Checkbox
+                            className="mt-0.5"
+                            checked={field.state.value}
+                            onCheckedChange={(value) => {
+                              setSubmitState(null);
+                              field.handleChange(Boolean(value));
+                            }}
+                          />
+                          <span className="space-y-1">
+                            <span className="block font-medium">
+                              Also sign me up for the KTH AI Society
+                              newsletter.
+                            </span>
+                            <span className="block text-muted-foreground">
+                              Optional. We&apos;ll use the details above to
+                              send you relevant updates, and you can
+                              unsubscribe at any time.
+                            </span>
+                          </span>
+                        </label>
+                      </Field>
+                    )}
                   </form.Field>
                 </div>
               );

--- a/src/components/applications/application-form.tsx
+++ b/src/components/applications/application-form.tsx
@@ -61,7 +61,13 @@ import {
   OTHER_PROGRAMME_VALUE,
   UNIVERSITIES,
   getGraduationYearOptions,
+  resolveUniversity,
+  resolveProgramme,
 } from "@/types/applications";
+import {
+  fieldIsInvalid,
+  selectableOptionBoxClassName,
+} from "@/lib/form-field-utils";
 
 const LINKEDIN_HANDLE_PREFIX = "linkedin.com/in/";
 const LINKEDIN_HANDLE_PATTERN = /^[A-Za-z0-9_-]{3,100}$/;
@@ -157,18 +163,6 @@ type ApplicationFormValues = {
   dataRetentionConsent: boolean;
   newsletterOptIn: boolean;
 };
-
-function resolveUniversity(values: Pick<ApplicationFormValues, "university" | "universityOther">) {
-  return values.university === OTHER_UNIVERSITY_VALUE
-    ? values.universityOther.trim()
-    : values.university.trim();
-}
-
-function resolveProgramme(values: Pick<ApplicationFormValues, "programme" | "programmeOther">) {
-  return values.programme === OTHER_PROGRAMME_VALUE
-    ? values.programmeOther.trim()
-    : values.programme.trim();
-}
 
 function normalizeWebsiteLink(value: string) {
   const trimmed = value.trim();
@@ -400,21 +394,6 @@ const applicationFieldValidators = {
     onChange: applicationBaseSchema.shape.newsletterOptIn,
   },
 };
-
-function fieldIsInvalid(
-  meta: { isTouched: boolean; isValid: boolean },
-  showErrors = false,
-) {
-  return (meta.isTouched || showErrors) && !meta.isValid;
-}
-
-function selectableOptionBoxClassName(isSelected: boolean, isInvalid = false) {
-  return cn(
-    "flex items-center gap-3 rounded-lg border p-3 text-sm transition-colors hover:bg-secondary/20",
-    isSelected && "border-primary/40 bg-primary/5",
-    isInvalid && !isSelected && "border-destructive/50",
-  );
-}
 
 const defaultApplicationValues: ApplicationFormValues = {
   firstName: "",

--- a/src/hooks/applications.ts
+++ b/src/hooks/applications.ts
@@ -41,6 +41,7 @@ async function submitGeneralApplication(
     "dataRetentionConsent",
     input.dataRetentionConsent ? "true" : "false",
   );
+  formData.append("newsletterOptIn", input.newsletterOptIn ? "true" : "false");
   formData.append("resume", input.resume);
 
   const response = await fetch(`${API_URL}/applications/general`, {

--- a/src/hooks/newsletter.ts
+++ b/src/hooks/newsletter.ts
@@ -1,0 +1,48 @@
+import { useMutation } from "@tanstack/react-query";
+import { API_URL } from "@/config";
+import type {
+  CreateNewsletterSubscriptionInput,
+  CreateNewsletterSubscriptionResponse,
+} from "@/types/newsletter";
+
+async function submitNewsletterSubscription(
+  input: CreateNewsletterSubscriptionInput,
+): Promise<CreateNewsletterSubscriptionResponse> {
+  const response = await fetch(`${API_URL}/newsletter/subscribe`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      firstName: input.firstName.trim(),
+      lastName: input.lastName.trim(),
+      email: input.email.trim(),
+      gender: input.gender,
+      university: input.university.trim(),
+      programme: input.programme.trim(),
+      graduationYear: input.graduationYear,
+      interests: input.interests,
+      dataRetentionConsent: input.dataRetentionConsent,
+    }),
+  });
+
+  const data = (await response.json().catch(() => null)) as
+    | { error?: string }
+    | CreateNewsletterSubscriptionResponse
+    | null;
+
+  if (!response.ok) {
+    const message =
+      data && "error" in data && data.error
+        ? data.error
+        : "Failed to subscribe to the newsletter";
+    throw new Error(message);
+  }
+
+  return data as CreateNewsletterSubscriptionResponse;
+}
+
+export function useSubmitNewsletterSubscription() {
+  return useMutation({
+    mutationFn: submitNewsletterSubscription,
+  });
+}

--- a/src/hooks/newsletter.ts
+++ b/src/hooks/newsletter.ts
@@ -7,7 +7,7 @@ import type {
 
 async function submitNewsletterSubscription(
   input: CreateNewsletterSubscriptionInput,
-): Promise<CreateNewsletterSubscriptionResponse> {
+): Promise<CreateNewsletterSubscriptionResponse | null> {
   const response = await fetch(`${API_URL}/newsletter/subscribe`, {
     method: "POST",
     credentials: "include",
@@ -38,7 +38,7 @@ async function submitNewsletterSubscription(
     throw new Error(message);
   }
 
-  return data as CreateNewsletterSubscriptionResponse;
+  return data as CreateNewsletterSubscriptionResponse | null;
 }
 
 export function useSubmitNewsletterSubscription() {

--- a/src/lib/form-field-utils.ts
+++ b/src/lib/form-field-utils.ts
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+// Shared by the application and newsletter forms: a field is only shown as
+// invalid once the user has interacted with it, unless the caller forces
+// errors to show (e.g. the application wizard's "review" step).
+export function fieldIsInvalid(
+  meta: { isTouched: boolean; isValid: boolean },
+  showErrors = false,
+) {
+  return (meta.isTouched || showErrors) && !meta.isValid;
+}
+
+export function selectableOptionBoxClassName(
+  isSelected: boolean,
+  isInvalid = false,
+) {
+  return cn(
+    "flex items-center gap-3 rounded-lg border p-3 text-sm transition-colors hover:bg-secondary/20",
+    isSelected && "border-primary/40 bg-primary/5",
+    isInvalid && !isSelected && "border-destructive/50",
+  );
+}

--- a/src/types/applications.ts
+++ b/src/types/applications.ts
@@ -36,6 +36,24 @@ export const APPLICATION_STATUSES = [
   "rejected",
 ] as const;
 
+// Shared with the newsletter signup form so both flows offer the same options.
+export const OTHER_PROGRAMME_VALUE = "Other / not listed";
+export const OTHER_UNIVERSITY_VALUE = "Other";
+export const UNIVERSITIES = [
+  "KTH Royal Institute of Technology",
+  "Stockholm University",
+  "Stockholm School of Economics",
+  "Karolinska Institutet",
+  "Södertörn University",
+  OTHER_UNIVERSITY_VALUE,
+] as const;
+
+export function getGraduationYearOptions(): string[] {
+  const currentYear = new Date().getFullYear();
+  // 6 years out covers students starting a 5-year programme this year.
+  return Array.from({ length: 6 }, (_, index) => String(currentYear + index));
+}
+
 export type ApplicationTeam = (typeof APPLICATION_TEAMS)[number];
 export type ApplicationAvailability = (typeof APPLICATION_AVAILABILITY)[number];
 export type ApplicationGender = (typeof APPLICATION_GENDERS)[number];
@@ -140,6 +158,7 @@ export type CreateGeneralApplicationInput = {
   availability: ApplicationAvailability;
   contribution: string;
   dataRetentionConsent: boolean;
+  newsletterOptIn: boolean;
 };
 
 export type CreateGeneralApplicationResponse = {

--- a/src/types/applications.ts
+++ b/src/types/applications.ts
@@ -54,6 +54,26 @@ export function getGraduationYearOptions(): string[] {
   return Array.from({ length: 6 }, (_, index) => String(currentYear + index));
 }
 
+// Shared by the application and newsletter forms, which both pair a select
+// with an "Other" free-text fallback for university/programme.
+export function resolveUniversity(values: {
+  university: string;
+  universityOther: string;
+}): string {
+  return values.university === OTHER_UNIVERSITY_VALUE
+    ? values.universityOther.trim()
+    : values.university.trim();
+}
+
+export function resolveProgramme(values: {
+  programme: string;
+  programmeOther: string;
+}): string {
+  return values.programme === OTHER_PROGRAMME_VALUE
+    ? values.programmeOther.trim()
+    : values.programme.trim();
+}
+
 export type ApplicationTeam = (typeof APPLICATION_TEAMS)[number];
 export type ApplicationAvailability = (typeof APPLICATION_AVAILABILITY)[number];
 export type ApplicationGender = (typeof APPLICATION_GENDERS)[number];

--- a/src/types/newsletter.ts
+++ b/src/types/newsletter.ts
@@ -1,0 +1,17 @@
+import type { ApplicationGender, ApplicationInterest } from "@/types/applications";
+
+export type CreateNewsletterSubscriptionInput = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  gender: ApplicationGender;
+  university: string;
+  programme: string;
+  graduationYear: number;
+  interests: ApplicationInterest[];
+  dataRetentionConsent: boolean;
+};
+
+export type CreateNewsletterSubscriptionResponse = {
+  status: string;
+};


### PR DESCRIPTION
## Summary
- Rebuilds the newsletter form to collect first/last name, email, gender, university, programme, graduation year, interests, and a required data-consent checkbox — matching the general application's field set and reusing its form components (`Field`, `NativeSelect`, `ProgrammeSelect`, `Checkbox`).
- Adds an optional "sign me up for the newsletter" checkbox to the application form's final consent step, right below the existing data-retention consent.
- Hoists the university list, graduation-year options, and "Other" sentinel values into `types/applications.ts` so both forms share one source of truth.
- **Review fix**: the university select silently defaulted to "KTH Royal Institute of Technology" with no neutral placeholder, so non-KTH users could submit incorrect data unnoticed — now defaults to an empty "Select your university" option like every other select in the form.
- **Review fix**: a copy-pasted placeholder on the "Other programme" field ("Your university and degree") corrected to "Enter your programme or degree".
- **Review fix**: the newsletter subscribe mutation cast a possibly-null response body to a non-null type; widened the return type to reflect reality.
- **Cleanup**: extracted `resolveUniversity`/`resolveProgramme` (into `types/applications.ts`) and `fieldIsInvalid`/`selectableOptionBoxClassName` (into new `lib/form-field-utils.ts`) — these were copy-pasted verbatim between the application form and the newsletter form.

## Test plan
- [x] `tsc --noEmit`, `next build`, `npm run lint`
- [x] Verified locally end-to-end: newsletter signup and the application opt-in checkbox both create rows in the backend's `newsletter_subscriptions` table
- [x] Verified the university placeholder fix and consent checkbox visually in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)