### PR TITLE
Add team-weighted "Total Applications" stat to admin dashboard

### DIFF
--- a/src/components/admin/applications/application-admin-panel.tsx
+++ b/src/components/admin/applications/application-admin-panel.tsx
@@ -994,7 +994,7 @@ export function ApplicationAdminPanel() {
         </div>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
+      <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-6">
         {[
           ["Unique Applicants", summary.total],
           ["Total Applications", summary.totalTeamApplications],

--- a/src/components/admin/applications/application-admin-panel.tsx
+++ b/src/components/admin/applications/application-admin-panel.tsx
@@ -845,6 +845,7 @@ export function ApplicationAdminPanel() {
   const summary = useMemo(() => {
     const counts = {
       total: applications.length,
+      totalTeamApplications: 0,
       pending: 0,
       reviewed: 0,
       accepted: 0,
@@ -852,6 +853,7 @@ export function ApplicationAdminPanel() {
     };
     applications.forEach((application) => {
       counts[application.status] += 1;
+      counts.totalTeamApplications += application.teams.length;
     });
     return counts;
   }, [applications]);
@@ -992,9 +994,10 @@ export function ApplicationAdminPanel() {
         </div>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
         {[
-          ["Total", summary.total],
+          ["Unique Applicants", summary.total],
+          ["Total Applications", summary.totalTeamApplications],
           ["Pending", summary.pending],
           ["Reviewed", summary.reviewed],
           ["Accepted", summary.accepted],


### PR DESCRIPTION
The existing "Total" stat counted unique applicants (one per GeneralApplication row). Adds a second stat, Total Applications, that sums each applicant's team count instead, so an applicant who ranked all 5 teams counts as 5 toward this number. Relabels the original stat "Unique Applicants" for clarity now that both are shown side-by-side.