### PR TITLE
Track clicks on job listing Apply button

### DIFF
--- a/src/components/admin/jobs/job-admin-panel.tsx
+++ b/src/components/admin/jobs/job-admin-panel.tsx
@@ -2,7 +2,15 @@
 
 import { useState, useMemo } from "react";
 import Fuse from "fuse.js";
-import { Plus, Search, Edit, Trash2, Briefcase, X } from "lucide-react";
+import {
+  Plus,
+  Search,
+  Edit,
+  Trash2,
+  Briefcase,
+  X,
+  MousePointerClick,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -149,6 +157,10 @@ export function JobAdminPanel() {
                           <p className="font-medium truncate">{job.title}</p>
                           <p className="text-sm text-muted-foreground truncate">
                             {job.company} • {job.jobType}
+                          </p>
+                          <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                            <MousePointerClick className="h-3 w-3" />
+                            {job.applyClickCount ?? 0} apply clicks
                           </p>
                         </div>
                       </div>

--- a/src/components/jobs/shared-job-view.tsx
+++ b/src/components/jobs/shared-job-view.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/ui/markdown";
 import { AsciiGrid } from "@/components/ui/ascii-grid";
-import { useCompany } from "@/hooks/admin";
+import { useCompany, trackJobApplyClick } from "@/hooks/admin";
 import { API_URL } from "@/config";
 import { normalizeExternalHref } from "@/lib/utils";
 import type { JobPostInput, FullJobListing, ContactDTO } from "@/hooks/admin";
@@ -29,6 +29,7 @@ export function SharedJobView({
 }) {
   const companyId = (job as Partial<JobPostInput>).companyId || (job as Partial<FullJobListing>).company;
   const appUrl = getJobApplyUrl(job);
+  const jobId = (job as Partial<FullJobListing>).id;
 
   let location = { place: "", tag: "" };
   try {
@@ -161,6 +162,7 @@ export function SharedJobView({
                         href={appUrl}
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={() => jobId && trackJobApplyClick(jobId)}
                       >
                         <ExternalLink className="mr-2 h-4 w-4" /> Apply Here
                       </a>

--- a/src/hooks/admin.ts
+++ b/src/hooks/admin.ts
@@ -481,11 +481,12 @@ export interface JobPostInput {
 export interface SmallJobListing {
   id: string;
   title: string;
-  company: string; 
-  companyId: string; 
+  company: string;
+  companyId: string;
   salary: string;
-  jobType: string; 
-  location: string; 
+  jobType: string;
+  location: string;
+  applyClickCount: number;
 }
 
 
@@ -494,13 +495,25 @@ export interface FullJobListing {
   title: string;
   description: string;
   salary: string;
-  location: string; 
+  location: string;
   jobType: string;
-  company: string; 
-  startdate: string; 
-  enddate: string; 
+  company: string;
+  startdate: string;
+  enddate: string;
   appurl: string;
-  contact: string; 
+  contact: string;
+  applyClickCount: number;
+}
+
+/**
+ * Fire-and-forget: records a click on a job listing's Apply button/link.
+ * Endpoint: POST /joblistings/click?id={id}
+ */
+export function trackJobApplyClick(id: string) {
+  fetch(`${API_URL}/joblistings/click?id=${id}`, {
+    method: "POST",
+    keepalive: true,
+  }).catch(() => {});
 }
 
 export function useJobs() {

--- a/src/hooks/admin.ts
+++ b/src/hooks/admin.ts
@@ -510,7 +510,7 @@ export interface FullJobListing {
  * Endpoint: POST /joblistings/click?id={id}
  */
 export function trackJobApplyClick(id: string) {
-  fetch(`${API_URL}/joblistings/click?id=${id}`, {
+  fetch(`${API_URL}/joblistings/click?id=${encodeURIComponent(id)}`, {
     method: "POST",
     keepalive: true,
   }).catch(() => {});


### PR DESCRIPTION
Fires a fire-and-forget request to the new backend click-tracking endpoint when a visitor clicks a job's external Apply link, and surfaces the resulting count per listing in the admin job panel.