### PR TITLE
Fix zoomed-in company logo images in job postings

### DIFF
--- a/src/app/business/jobs/page.tsx
+++ b/src/app/business/jobs/page.tsx
@@ -67,7 +67,8 @@ function JobCard({ job }: { job: SmallJobListing & { companyLogo?: string | null
   return (
     <Link href={`/business/jobs/${job.id}`}>
       <ImageCard
-        image={job.companyLogo || coverImage} // Falls back to cover if no logo
+        image={coverImage}
+        fallbackImage="/project-placeholder.webp"
         alt={job.company || "Company"}
         blurHeight="70%"
         gradientColors={gradientColors}

--- a/src/components/home/jobs-preview.tsx
+++ b/src/components/home/jobs-preview.tsx
@@ -44,7 +44,8 @@ function JobCard({ job }: { job: SmallJobListing & { companyLogo?: string | null
   return (
     <Link href={`/business/jobs/${job.id}`}>
       <ImageCard
-        image={job.companyLogo || coverImage}
+        image={coverImage}
+        fallbackImage="/project-placeholder.webp"
         alt={job.company || "Company"}
         blurHeight="70%"
         gradientColors={gradientColors}


### PR DESCRIPTION
This PR fixes the issue where company logos were being stretched/zoomed-in as background images for job posting cards. It switches the card background to use the company's cover image with a fallback to the generic project-placeholder.webp.